### PR TITLE
simplify

### DIFF
--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -173,5 +173,11 @@ fn test_from_anki() {
         .shuffle(42)
         .num_workers(4)
         .build(dataset);
-    dbg!(dataloader.iter().next().expect("loader is empty").r_historys);
+    dbg!(
+        dataloader
+            .iter()
+            .next()
+            .expect("loader is empty")
+            .r_historys
+    );
 }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -160,8 +160,7 @@ fn test_from_anki() {
     use burn::data::dataset::InMemDataset;
 
     let dataset = InMemDataset::<FSRSItem>::new(anki_to_fsrs());
-    let item = dataset.get(704).unwrap();
-    dbg!(&item);
+    dbg!(dataset.get(704).unwrap());
 
     use burn_ndarray::NdArrayDevice;
     let device = NdArrayDevice::Cpu;
@@ -174,8 +173,5 @@ fn test_from_anki() {
         .shuffle(42)
         .num_workers(4)
         .build(dataset);
-    for item in dataloader.iter() {
-        dbg!(&item.r_historys);
-        break;
-    }
+    dbg!(dataloader.iter().next().expect("loader is empty").r_historys);
 }


### PR DESCRIPTION
I checked the implement, `get` has `clone`, so just use it.
use `.iter().next().expect("..")` is shorter than `for in + break`